### PR TITLE
Fix search input selection on IPhone

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -139,6 +139,7 @@ export default function SearchInput(props: Props) {
 											dir="auto"
 											class={styles.result}
 											onClick={[handleResultClick, name]}
+											onTouchEnd={[handleResultClick, name]}
 											type="button"
 										>
 											{arabicLettersRegex.test(name) ? (


### PR DESCRIPTION
# Description

On iPhone devices when you search on search input and try to select one of results, It not work properly

## Which issue does this PR resolve?

Resolves #66

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist (check all that don't apply as well):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
